### PR TITLE
Build manifest for org.darktable.Darktable

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "skip-arches": ["arm"]
+}

--- a/org.darktable.Darktable.json
+++ b/org.darktable.Darktable.json
@@ -80,7 +80,8 @@
             "name": "darktable",
             "cmake": true,
             "config-opts": [
-                "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+                "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+                "-DBINARY_PACKAGE_BUILD=1"
             ],
             "builddir": true,
             "build-options": {

--- a/org.darktable.Darktable.json
+++ b/org.darktable.Darktable.json
@@ -42,6 +42,16 @@
             "config-opts": [
                 "-DCMAKE_INSTALL_LIBDIR=/app/lib"
             ],
+            "build-options": {
+                "arch": {
+                    "aarch64": {
+                        "config-opts": [
+                            "-DBUILD_FOR_SSE=0",
+                            "-DBUILD_FOR_SSE2=0"
+                        ]
+                    }
+                }
+            },
             "sources": [
                 {
                     "type": "archive",

--- a/org.darktable.Darktable.json
+++ b/org.darktable.Darktable.json
@@ -1,0 +1,124 @@
+{
+    "app-id": "org.darktable.Darktable",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "3.24",
+    "sdk": "org.gnome.Sdk",
+    "command": "darktable",
+    "rename-desktop-file": "darktable.desktop",
+    "rename-appdata-file": "darktable.appdata.xml",
+    "rename-icon": "darktable",
+    "finish-args": [
+        "--share=ipc",
+        "--socket=x11",
+        "--filesystem=host",
+        "--talk-name=org.freedesktop.secrets",
+        /* Needed for dconf to work */
+        "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
+        "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+    ],
+    "build-options": {
+        "cflags": "-O2",
+        "cxxflags": "-O2 -std=c++11",
+        "env": {
+            "V": "1"
+        }
+    },
+    "cleanup": [
+        "/include",
+        "/bin/exiv2*",
+        "/bin/*lensfun*",
+        "/bin/xml*",
+        "/bin/xslt*",
+        "/bin/metacopy",
+        "/bin/pathtest",
+        "/lib/cmake",
+        "/lib/pkgconfig",
+        "/man",
+        "*.a",
+        "*.la"
+    ],
+    "modules": [
+        {
+            "name": "lensfun",
+            "cmake": true,
+            "config-opts": [
+                "-DCMAKE_INSTALL_LIBDIR=/app/lib"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://downloads.sourceforge.net/project/lensfun/0.3.2/lensfun-0.3.2.tar.gz",
+                    "sha256": "ae8bcad46614ca47f5bda65b00af4a257a9564a61725df9c74cb260da544d331"
+                }
+            ]
+        },
+        {
+            "name": "libxml2",
+            "config-opts": [
+                "--with-python=no"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "git://git.gnome.org/libxml2"
+                }
+            ]
+        },
+        {
+            "name": "libxslt",
+            "config-opts": [
+                "--with-crypto=no"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "git://git.gnome.org/libxslt"
+                }
+            ]
+        },
+        {
+            "name": "exiv2",
+            "cmake": true,
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://www.exiv2.org/exiv2-0.25.tar.gz",
+                    "sha256": "c80bfc778a15fdb06f71265db2c3d49d8493c382e516cb99b8c9f9cbde36efa4"
+                }
+            ]
+        },
+        {
+            "name": "pugixml",
+            "cmake": true,
+            "build-options": {
+                "cflags": "-fPIC",
+                "cxxflags": "-fPIC"
+            },
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://github.com/zeux/pugixml/releases/download/v1.8/pugixml-1.8.tar.gz",
+                    "sha256": "8ef26a51c670fbe79a71e9af94df4884d5a4b00a2db38a0608a87c14113b2904"
+                }
+            ]
+        },
+        {
+            "name": "darktable",
+            "cmake": true,
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+            ],
+            "builddir": true,
+            "build-options": {
+                "cflags": "-O2 -std=c99"
+            },
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/darktable-org/darktable/releases/download/release-2.2.3/darktable-2.2.3.tar.xz",
+                    "sha256": "1b33859585bf283577680c61e3c0ea4e48214371453b9c17a86664d2fbda48a0"
+                }
+            ]
+        }
+    ]
+}

--- a/org.darktable.Darktable.json
+++ b/org.darktable.Darktable.json
@@ -27,8 +27,6 @@
         "/include",
         "/bin/exiv2*",
         "/bin/*lensfun*",
-        "/bin/xml*",
-        "/bin/xslt*",
         "/bin/metacopy",
         "/bin/pathtest",
         "/lib/cmake",
@@ -49,30 +47,6 @@
                     "type": "archive",
                     "url": "https://downloads.sourceforge.net/project/lensfun/0.3.2/lensfun-0.3.2.tar.gz",
                     "sha256": "ae8bcad46614ca47f5bda65b00af4a257a9564a61725df9c74cb260da544d331"
-                }
-            ]
-        },
-        {
-            "name": "libxml2",
-            "config-opts": [
-                "--with-python=no"
-            ],
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "git://git.gnome.org/libxml2"
-                }
-            ]
-        },
-        {
-            "name": "libxslt",
-            "config-opts": [
-                "--with-crypto=no"
-            ],
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "git://git.gnome.org/libxslt"
                 }
             ]
         },

--- a/org.darktable.Darktable.json
+++ b/org.darktable.Darktable.json
@@ -89,8 +89,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/darktable-org/darktable/releases/download/release-2.2.3/darktable-2.2.3.tar.xz",
-                    "sha256": "1b33859585bf283577680c61e3c0ea4e48214371453b9c17a86664d2fbda48a0"
+                    "url": "https://github.com/darktable-org/darktable/releases/download/release-2.2.4/darktable-2.2.4.tar.xz",
+                    "sha256": "bd5445d6b81fc3288fb07362870e24bb0b5378cacad2c6e6602e32de676bf9d8"
                 }
             ]
         }


### PR DESCRIPTION
There is an open issue about getting OpenCL to work in flatpaks (see https://github.com/flatpak/flatpak/issues/574) however Darktable also works without OpenCL support (although a bit slow).